### PR TITLE
7904 Add is_survey flag to all econ tables

### DIFF
--- a/config/econ.json
+++ b/config/econ.json
@@ -2,6 +2,7 @@
   {
     "base": {
       "title": "Educational Attainment (Highest Grade Completed)",
+      "is_survey": true,
       "vintages": [
         "CENSUS PUMS, 2000",
         "ACS PUMS, 2008-2012",
@@ -82,6 +83,7 @@
   {
     "base": {
       "title": "Median Household Income (2019 Dollars)",
+      "is_survey": true,
       "vintages": [
         "ACS PUMS, 2008-2012",
         "ACS PUMS, 2015-19"
@@ -156,6 +158,7 @@
   {
     "base": {
       "title": "Households By Area Median Income (AMI) Band",
+      "is_survey": true,
       "vintages": [
         "ACS PUMS, 2015-19"
       ],
@@ -233,6 +236,7 @@
   {
     "base": {
       "title": "Labor Force",
+      "is_survey": true,
       "vintages": [
         "ACS PUMS, 2008-2012",
         "ACS PUMS, 2015-19"
@@ -312,6 +316,7 @@
   {
     "base": {
       "title": "Occupation",
+      "is_survey": true,
       "vintages": [
         "ACS PUMS, 2008-2012",
         "ACS PUMS, 2015-19"
@@ -395,6 +400,7 @@
   {
     "base": {
       "title": "Median Wages By Occupation (2019 Dollars)",
+      "is_survey": true,
       "vintages": [
         "ACS PUMS, 2008-2012",
         "ACS PUMS, 2015-19"
@@ -475,6 +481,7 @@
   {
     "base": {
       "title": "Industry",
+      "is_survey": true,
       "vintages": [
         "ACS PUMS, 2008-2012",
         "ACS PUMS, 2015-19"
@@ -566,6 +573,7 @@
   {
     "base": {
       "title": "Median Wages By Industry (2019 Dollars)",
+      "is_survey": true,
       "vintages": [
         "ACS PUMS, 2008-2012",
         "ACS PUMS, 2015-19"

--- a/generated/resolved_pages.json
+++ b/generated/resolved_pages.json
@@ -7619,7 +7619,7 @@
             "NONE",
             "MOE"
           ],
-          "is_survey": false,
+          "is_survey": true,
           "denominator": {
             "label": "Population 25 years and over",
             "measures": [
@@ -7796,7 +7796,7 @@
             "MOE",
             "CV"
           ],
-          "is_survey": false,
+          "is_survey": true,
           "denominator": {
             "label": "Total households",
             "measures": [
@@ -7885,7 +7885,7 @@
             "MOE",
             "CV"
           ],
-          "is_survey": false,
+          "is_survey": true,
           "denominator": {
             "label": "Total households",
             "measures": [
@@ -8000,7 +8000,7 @@
             "NONE",
             "MOE"
           ],
-          "is_survey": false,
+          "is_survey": true,
           "denominator": {
             "label": "Total population 16 to 64 years",
             "measures": [
@@ -8118,7 +8118,7 @@
             "NONE",
             "MOE"
           ],
-          "is_survey": false,
+          "is_survey": true,
           "denominator": {
             "label": "Civilian employed population 16 to 64 years",
             "measures": [
@@ -8276,7 +8276,7 @@
             "MOE",
             "CV"
           ],
-          "is_survey": false,
+          "is_survey": true,
           "denominator": {
             "label": "Civilian employed population 16 to 64 years",
             "measures": [
@@ -8430,7 +8430,7 @@
             "NONE",
             "MOE"
           ],
-          "is_survey": false,
+          "is_survey": true,
           "denominator": {
             "label": "Civilian employed population 16 to 64 years",
             "measures": [
@@ -8708,7 +8708,7 @@
             "MOE",
             "CV"
           ],
-          "is_survey": false,
+          "is_survey": true,
           "denominator": {
             "label": "Civilian employed population 16 to 64 years",
             "measures": [
@@ -8937,7 +8937,7 @@
             "NONE",
             "MOE"
           ],
-          "is_survey": false,
+          "is_survey": true,
           "denominator": {
             "label": "Asian non-Hispanic population 25 years and over",
             "measures": [
@@ -9114,7 +9114,7 @@
             "MOE",
             "CV"
           ],
-          "is_survey": false,
+          "is_survey": true,
           "denominator": {
             "label": "Total households with an Asian non-Hispanic householder",
             "measures": [
@@ -9203,7 +9203,7 @@
             "MOE",
             "CV"
           ],
-          "is_survey": false,
+          "is_survey": true,
           "denominator": {
             "label": "Total households with an Asian non-Hispanic householder",
             "measures": [
@@ -9318,7 +9318,7 @@
             "NONE",
             "MOE"
           ],
-          "is_survey": false,
+          "is_survey": true,
           "denominator": {
             "label": "Asian non-Hispanic 16 to 64 years",
             "measures": [
@@ -9436,7 +9436,7 @@
             "NONE",
             "MOE"
           ],
-          "is_survey": false,
+          "is_survey": true,
           "denominator": {
             "label": "Asian non-Hispanic civilian employed population 16 to 64 years",
             "measures": [
@@ -9594,7 +9594,7 @@
             "MOE",
             "CV"
           ],
-          "is_survey": false,
+          "is_survey": true,
           "denominator": {
             "label": "Asian non-Hispanic civilian employed population 16 to 64 years",
             "measures": [
@@ -9748,7 +9748,7 @@
             "NONE",
             "MOE"
           ],
-          "is_survey": false,
+          "is_survey": true,
           "denominator": {
             "label": "Asian non-Hispanic civilian employed population 16 to 64 years",
             "measures": [
@@ -10026,7 +10026,7 @@
             "MOE",
             "CV"
           ],
-          "is_survey": false,
+          "is_survey": true,
           "denominator": {
             "label": "Asian non-Hispanic civilian employed population 16 to 64 years",
             "measures": [
@@ -10255,7 +10255,7 @@
             "NONE",
             "MOE"
           ],
-          "is_survey": false,
+          "is_survey": true,
           "denominator": {
             "label": "Black non-Hispanic population 25 years and over",
             "measures": [
@@ -10432,7 +10432,7 @@
             "MOE",
             "CV"
           ],
-          "is_survey": false,
+          "is_survey": true,
           "denominator": {
             "label": "Total households with a Black non-Hispanic householder",
             "measures": [
@@ -10521,7 +10521,7 @@
             "MOE",
             "CV"
           ],
-          "is_survey": false,
+          "is_survey": true,
           "denominator": {
             "label": "Total households with a Black non-Hispanic householder",
             "measures": [
@@ -10636,7 +10636,7 @@
             "NONE",
             "MOE"
           ],
-          "is_survey": false,
+          "is_survey": true,
           "denominator": {
             "label": "Black non-Hispanic 16 to 64 years",
             "measures": [
@@ -10754,7 +10754,7 @@
             "NONE",
             "MOE"
           ],
-          "is_survey": false,
+          "is_survey": true,
           "denominator": {
             "label": "Black non-Hispanic civilian employed population 16 to 64 years",
             "measures": [
@@ -10912,7 +10912,7 @@
             "MOE",
             "CV"
           ],
-          "is_survey": false,
+          "is_survey": true,
           "denominator": {
             "label": "Black non-Hispanic civilian employed population 16 to 64 years",
             "measures": [
@@ -11066,7 +11066,7 @@
             "NONE",
             "MOE"
           ],
-          "is_survey": false,
+          "is_survey": true,
           "denominator": {
             "label": "Black non-Hispanic civilian employed population 16 to 64 years",
             "measures": [
@@ -11344,7 +11344,7 @@
             "MOE",
             "CV"
           ],
-          "is_survey": false,
+          "is_survey": true,
           "denominator": {
             "label": "Black non-Hispanic civilian employed population 16 to 64 years",
             "measures": [
@@ -11573,7 +11573,7 @@
             "NONE",
             "MOE"
           ],
-          "is_survey": false,
+          "is_survey": true,
           "denominator": {
             "label": "Hispanic population 25 years and over",
             "measures": [
@@ -11750,7 +11750,7 @@
             "MOE",
             "CV"
           ],
-          "is_survey": false,
+          "is_survey": true,
           "denominator": {
             "label": "Total households with a Hispanic householder",
             "measures": [
@@ -11839,7 +11839,7 @@
             "MOE",
             "CV"
           ],
-          "is_survey": false,
+          "is_survey": true,
           "denominator": {
             "label": "Total households with a Hispanic householder",
             "measures": [
@@ -11954,7 +11954,7 @@
             "NONE",
             "MOE"
           ],
-          "is_survey": false,
+          "is_survey": true,
           "denominator": {
             "label": "Hispanic 16 to 64 years",
             "measures": [
@@ -12072,7 +12072,7 @@
             "NONE",
             "MOE"
           ],
-          "is_survey": false,
+          "is_survey": true,
           "denominator": {
             "label": "Hispanic civilian employed population 16 to 64 years",
             "measures": [
@@ -12230,7 +12230,7 @@
             "MOE",
             "CV"
           ],
-          "is_survey": false,
+          "is_survey": true,
           "denominator": {
             "label": "Hispanic civilian employed population 16 to 64 years",
             "measures": [
@@ -12384,7 +12384,7 @@
             "NONE",
             "MOE"
           ],
-          "is_survey": false,
+          "is_survey": true,
           "denominator": {
             "label": "Hispanic civilian employed population 16 to 64 years",
             "measures": [
@@ -12662,7 +12662,7 @@
             "MOE",
             "CV"
           ],
-          "is_survey": false,
+          "is_survey": true,
           "denominator": {
             "label": "Hispanic civilian employed population 16 to 64 years",
             "measures": [
@@ -12891,7 +12891,7 @@
             "NONE",
             "MOE"
           ],
-          "is_survey": false,
+          "is_survey": true,
           "denominator": {
             "label": "White non-Hispanic population 25 years and over",
             "measures": [
@@ -13068,7 +13068,7 @@
             "MOE",
             "CV"
           ],
-          "is_survey": false,
+          "is_survey": true,
           "denominator": {
             "label": "Total households with a White non-Hispanic householder",
             "measures": [
@@ -13157,7 +13157,7 @@
             "MOE",
             "CV"
           ],
-          "is_survey": false,
+          "is_survey": true,
           "denominator": {
             "label": "Total households with a White non-Hispanic householder",
             "measures": [
@@ -13272,7 +13272,7 @@
             "NONE",
             "MOE"
           ],
-          "is_survey": false,
+          "is_survey": true,
           "denominator": {
             "label": "White non-Hispanic 16 to 64 years",
             "measures": [
@@ -13390,7 +13390,7 @@
             "NONE",
             "MOE"
           ],
-          "is_survey": false,
+          "is_survey": true,
           "denominator": {
             "label": "White non-Hispanic civilian employed population 16 to 64 years",
             "measures": [
@@ -13548,7 +13548,7 @@
             "MOE",
             "CV"
           ],
-          "is_survey": false,
+          "is_survey": true,
           "denominator": {
             "label": "White non-Hispanic civilian employed population 16 to 64 years",
             "measures": [
@@ -13702,7 +13702,7 @@
             "NONE",
             "MOE"
           ],
-          "is_survey": false,
+          "is_survey": true,
           "denominator": {
             "label": "White non-Hispanic civilian employed population 16 to 64 years",
             "measures": [
@@ -13980,7 +13980,7 @@
             "MOE",
             "CV"
           ],
-          "is_survey": false,
+          "is_survey": true,
           "denominator": {
             "label": "White non-Hispanic civilian employed population 16 to 64 years",
             "measures": [
@@ -26277,7 +26277,7 @@
             "NONE",
             "MOE"
           ],
-          "is_survey": false,
+          "is_survey": true,
           "denominator": {
             "label": "Population 25 years and over",
             "measures": [
@@ -26454,7 +26454,7 @@
             "MOE",
             "CV"
           ],
-          "is_survey": false,
+          "is_survey": true,
           "denominator": {
             "label": "Total households",
             "measures": [
@@ -26543,7 +26543,7 @@
             "MOE",
             "CV"
           ],
-          "is_survey": false,
+          "is_survey": true,
           "denominator": {
             "label": "Total households",
             "measures": [
@@ -26658,7 +26658,7 @@
             "NONE",
             "MOE"
           ],
-          "is_survey": false,
+          "is_survey": true,
           "denominator": {
             "label": "Total population 16 to 64 years",
             "measures": [
@@ -26776,7 +26776,7 @@
             "NONE",
             "MOE"
           ],
-          "is_survey": false,
+          "is_survey": true,
           "denominator": {
             "label": "Civilian employed population 16 to 64 years",
             "measures": [
@@ -26934,7 +26934,7 @@
             "MOE",
             "CV"
           ],
-          "is_survey": false,
+          "is_survey": true,
           "denominator": {
             "label": "Civilian employed population 16 to 64 years",
             "measures": [
@@ -27088,7 +27088,7 @@
             "NONE",
             "MOE"
           ],
-          "is_survey": false,
+          "is_survey": true,
           "denominator": {
             "label": "Civilian employed population 16 to 64 years",
             "measures": [
@@ -27366,7 +27366,7 @@
             "MOE",
             "CV"
           ],
-          "is_survey": false,
+          "is_survey": true,
           "denominator": {
             "label": "Civilian employed population 16 to 64 years",
             "measures": [
@@ -27595,7 +27595,7 @@
             "NONE",
             "MOE"
           ],
-          "is_survey": false,
+          "is_survey": true,
           "denominator": {
             "label": "Asian non-Hispanic population 25 years and over",
             "measures": [
@@ -27772,7 +27772,7 @@
             "MOE",
             "CV"
           ],
-          "is_survey": false,
+          "is_survey": true,
           "denominator": {
             "label": "Total households with an Asian non-Hispanic householder",
             "measures": [
@@ -27861,7 +27861,7 @@
             "MOE",
             "CV"
           ],
-          "is_survey": false,
+          "is_survey": true,
           "denominator": {
             "label": "Total households with an Asian non-Hispanic householder",
             "measures": [
@@ -27976,7 +27976,7 @@
             "NONE",
             "MOE"
           ],
-          "is_survey": false,
+          "is_survey": true,
           "denominator": {
             "label": "Asian non-Hispanic 16 to 64 years",
             "measures": [
@@ -28094,7 +28094,7 @@
             "NONE",
             "MOE"
           ],
-          "is_survey": false,
+          "is_survey": true,
           "denominator": {
             "label": "Asian non-Hispanic civilian employed population 16 to 64 years",
             "measures": [
@@ -28252,7 +28252,7 @@
             "MOE",
             "CV"
           ],
-          "is_survey": false,
+          "is_survey": true,
           "denominator": {
             "label": "Asian non-Hispanic civilian employed population 16 to 64 years",
             "measures": [
@@ -28406,7 +28406,7 @@
             "NONE",
             "MOE"
           ],
-          "is_survey": false,
+          "is_survey": true,
           "denominator": {
             "label": "Asian non-Hispanic civilian employed population 16 to 64 years",
             "measures": [
@@ -28684,7 +28684,7 @@
             "MOE",
             "CV"
           ],
-          "is_survey": false,
+          "is_survey": true,
           "denominator": {
             "label": "Asian non-Hispanic civilian employed population 16 to 64 years",
             "measures": [
@@ -28913,7 +28913,7 @@
             "NONE",
             "MOE"
           ],
-          "is_survey": false,
+          "is_survey": true,
           "denominator": {
             "label": "Black non-Hispanic population 25 years and over",
             "measures": [
@@ -29090,7 +29090,7 @@
             "MOE",
             "CV"
           ],
-          "is_survey": false,
+          "is_survey": true,
           "denominator": {
             "label": "Total households with a Black non-Hispanic householder",
             "measures": [
@@ -29179,7 +29179,7 @@
             "MOE",
             "CV"
           ],
-          "is_survey": false,
+          "is_survey": true,
           "denominator": {
             "label": "Total households with a Black non-Hispanic householder",
             "measures": [
@@ -29294,7 +29294,7 @@
             "NONE",
             "MOE"
           ],
-          "is_survey": false,
+          "is_survey": true,
           "denominator": {
             "label": "Black non-Hispanic 16 to 64 years",
             "measures": [
@@ -29412,7 +29412,7 @@
             "NONE",
             "MOE"
           ],
-          "is_survey": false,
+          "is_survey": true,
           "denominator": {
             "label": "Black non-Hispanic civilian employed population 16 to 64 years",
             "measures": [
@@ -29570,7 +29570,7 @@
             "MOE",
             "CV"
           ],
-          "is_survey": false,
+          "is_survey": true,
           "denominator": {
             "label": "Black non-Hispanic civilian employed population 16 to 64 years",
             "measures": [
@@ -29724,7 +29724,7 @@
             "NONE",
             "MOE"
           ],
-          "is_survey": false,
+          "is_survey": true,
           "denominator": {
             "label": "Black non-Hispanic civilian employed population 16 to 64 years",
             "measures": [
@@ -30002,7 +30002,7 @@
             "MOE",
             "CV"
           ],
-          "is_survey": false,
+          "is_survey": true,
           "denominator": {
             "label": "Black non-Hispanic civilian employed population 16 to 64 years",
             "measures": [
@@ -30231,7 +30231,7 @@
             "NONE",
             "MOE"
           ],
-          "is_survey": false,
+          "is_survey": true,
           "denominator": {
             "label": "Hispanic population 25 years and over",
             "measures": [
@@ -30408,7 +30408,7 @@
             "MOE",
             "CV"
           ],
-          "is_survey": false,
+          "is_survey": true,
           "denominator": {
             "label": "Total households with a Hispanic householder",
             "measures": [
@@ -30497,7 +30497,7 @@
             "MOE",
             "CV"
           ],
-          "is_survey": false,
+          "is_survey": true,
           "denominator": {
             "label": "Total households with a Hispanic householder",
             "measures": [
@@ -30612,7 +30612,7 @@
             "NONE",
             "MOE"
           ],
-          "is_survey": false,
+          "is_survey": true,
           "denominator": {
             "label": "Hispanic 16 to 64 years",
             "measures": [
@@ -30730,7 +30730,7 @@
             "NONE",
             "MOE"
           ],
-          "is_survey": false,
+          "is_survey": true,
           "denominator": {
             "label": "Hispanic civilian employed population 16 to 64 years",
             "measures": [
@@ -30888,7 +30888,7 @@
             "MOE",
             "CV"
           ],
-          "is_survey": false,
+          "is_survey": true,
           "denominator": {
             "label": "Hispanic civilian employed population 16 to 64 years",
             "measures": [
@@ -31042,7 +31042,7 @@
             "NONE",
             "MOE"
           ],
-          "is_survey": false,
+          "is_survey": true,
           "denominator": {
             "label": "Hispanic civilian employed population 16 to 64 years",
             "measures": [
@@ -31320,7 +31320,7 @@
             "MOE",
             "CV"
           ],
-          "is_survey": false,
+          "is_survey": true,
           "denominator": {
             "label": "Hispanic civilian employed population 16 to 64 years",
             "measures": [
@@ -31549,7 +31549,7 @@
             "NONE",
             "MOE"
           ],
-          "is_survey": false,
+          "is_survey": true,
           "denominator": {
             "label": "White non-Hispanic population 25 years and over",
             "measures": [
@@ -31726,7 +31726,7 @@
             "MOE",
             "CV"
           ],
-          "is_survey": false,
+          "is_survey": true,
           "denominator": {
             "label": "Total households with a White non-Hispanic householder",
             "measures": [
@@ -31815,7 +31815,7 @@
             "MOE",
             "CV"
           ],
-          "is_survey": false,
+          "is_survey": true,
           "denominator": {
             "label": "Total households with a White non-Hispanic householder",
             "measures": [
@@ -31930,7 +31930,7 @@
             "NONE",
             "MOE"
           ],
-          "is_survey": false,
+          "is_survey": true,
           "denominator": {
             "label": "White non-Hispanic 16 to 64 years",
             "measures": [
@@ -32048,7 +32048,7 @@
             "NONE",
             "MOE"
           ],
-          "is_survey": false,
+          "is_survey": true,
           "denominator": {
             "label": "White non-Hispanic civilian employed population 16 to 64 years",
             "measures": [
@@ -32206,7 +32206,7 @@
             "MOE",
             "CV"
           ],
-          "is_survey": false,
+          "is_survey": true,
           "denominator": {
             "label": "White non-Hispanic civilian employed population 16 to 64 years",
             "measures": [
@@ -32360,7 +32360,7 @@
             "NONE",
             "MOE"
           ],
-          "is_survey": false,
+          "is_survey": true,
           "denominator": {
             "label": "White non-Hispanic civilian employed population 16 to 64 years",
             "measures": [
@@ -32638,7 +32638,7 @@
             "MOE",
             "CV"
           ],
-          "is_survey": false,
+          "is_survey": true,
           "denominator": {
             "label": "White non-Hispanic civilian employed population 16 to 64 years",
             "measures": [
@@ -44939,7 +44939,7 @@
             "NONE",
             "MOE"
           ],
-          "is_survey": false,
+          "is_survey": true,
           "denominator": {
             "label": "Population 25 years and over",
             "measures": [
@@ -45116,7 +45116,7 @@
             "MOE",
             "CV"
           ],
-          "is_survey": false,
+          "is_survey": true,
           "denominator": {
             "label": "Total households",
             "measures": [
@@ -45205,7 +45205,7 @@
             "MOE",
             "CV"
           ],
-          "is_survey": false,
+          "is_survey": true,
           "denominator": {
             "label": "Total households",
             "measures": [
@@ -45320,7 +45320,7 @@
             "NONE",
             "MOE"
           ],
-          "is_survey": false,
+          "is_survey": true,
           "denominator": {
             "label": "Total population 16 to 64 years",
             "measures": [
@@ -45438,7 +45438,7 @@
             "NONE",
             "MOE"
           ],
-          "is_survey": false,
+          "is_survey": true,
           "denominator": {
             "label": "Civilian employed population 16 to 64 years",
             "measures": [
@@ -45596,7 +45596,7 @@
             "MOE",
             "CV"
           ],
-          "is_survey": false,
+          "is_survey": true,
           "denominator": {
             "label": "Civilian employed population 16 to 64 years",
             "measures": [
@@ -45750,7 +45750,7 @@
             "NONE",
             "MOE"
           ],
-          "is_survey": false,
+          "is_survey": true,
           "denominator": {
             "label": "Civilian employed population 16 to 64 years",
             "measures": [
@@ -46028,7 +46028,7 @@
             "MOE",
             "CV"
           ],
-          "is_survey": false,
+          "is_survey": true,
           "denominator": {
             "label": "Civilian employed population 16 to 64 years",
             "measures": [
@@ -46257,7 +46257,7 @@
             "NONE",
             "MOE"
           ],
-          "is_survey": false,
+          "is_survey": true,
           "denominator": {
             "label": "Asian non-Hispanic population 25 years and over",
             "measures": [
@@ -46434,7 +46434,7 @@
             "MOE",
             "CV"
           ],
-          "is_survey": false,
+          "is_survey": true,
           "denominator": {
             "label": "Total households with an Asian non-Hispanic householder",
             "measures": [
@@ -46523,7 +46523,7 @@
             "MOE",
             "CV"
           ],
-          "is_survey": false,
+          "is_survey": true,
           "denominator": {
             "label": "Total households with an Asian non-Hispanic householder",
             "measures": [
@@ -46638,7 +46638,7 @@
             "NONE",
             "MOE"
           ],
-          "is_survey": false,
+          "is_survey": true,
           "denominator": {
             "label": "Asian non-Hispanic 16 to 64 years",
             "measures": [
@@ -46756,7 +46756,7 @@
             "NONE",
             "MOE"
           ],
-          "is_survey": false,
+          "is_survey": true,
           "denominator": {
             "label": "Asian non-Hispanic civilian employed population 16 to 64 years",
             "measures": [
@@ -46914,7 +46914,7 @@
             "MOE",
             "CV"
           ],
-          "is_survey": false,
+          "is_survey": true,
           "denominator": {
             "label": "Asian non-Hispanic civilian employed population 16 to 64 years",
             "measures": [
@@ -47068,7 +47068,7 @@
             "NONE",
             "MOE"
           ],
-          "is_survey": false,
+          "is_survey": true,
           "denominator": {
             "label": "Asian non-Hispanic civilian employed population 16 to 64 years",
             "measures": [
@@ -47346,7 +47346,7 @@
             "MOE",
             "CV"
           ],
-          "is_survey": false,
+          "is_survey": true,
           "denominator": {
             "label": "Asian non-Hispanic civilian employed population 16 to 64 years",
             "measures": [
@@ -47575,7 +47575,7 @@
             "NONE",
             "MOE"
           ],
-          "is_survey": false,
+          "is_survey": true,
           "denominator": {
             "label": "Black non-Hispanic population 25 years and over",
             "measures": [
@@ -47752,7 +47752,7 @@
             "MOE",
             "CV"
           ],
-          "is_survey": false,
+          "is_survey": true,
           "denominator": {
             "label": "Total households with a Black non-Hispanic householder",
             "measures": [
@@ -47841,7 +47841,7 @@
             "MOE",
             "CV"
           ],
-          "is_survey": false,
+          "is_survey": true,
           "denominator": {
             "label": "Total households with a Black non-Hispanic householder",
             "measures": [
@@ -47956,7 +47956,7 @@
             "NONE",
             "MOE"
           ],
-          "is_survey": false,
+          "is_survey": true,
           "denominator": {
             "label": "Black non-Hispanic 16 to 64 years",
             "measures": [
@@ -48074,7 +48074,7 @@
             "NONE",
             "MOE"
           ],
-          "is_survey": false,
+          "is_survey": true,
           "denominator": {
             "label": "Black non-Hispanic civilian employed population 16 to 64 years",
             "measures": [
@@ -48232,7 +48232,7 @@
             "MOE",
             "CV"
           ],
-          "is_survey": false,
+          "is_survey": true,
           "denominator": {
             "label": "Black non-Hispanic civilian employed population 16 to 64 years",
             "measures": [
@@ -48386,7 +48386,7 @@
             "NONE",
             "MOE"
           ],
-          "is_survey": false,
+          "is_survey": true,
           "denominator": {
             "label": "Black non-Hispanic civilian employed population 16 to 64 years",
             "measures": [
@@ -48664,7 +48664,7 @@
             "MOE",
             "CV"
           ],
-          "is_survey": false,
+          "is_survey": true,
           "denominator": {
             "label": "Black non-Hispanic civilian employed population 16 to 64 years",
             "measures": [
@@ -48893,7 +48893,7 @@
             "NONE",
             "MOE"
           ],
-          "is_survey": false,
+          "is_survey": true,
           "denominator": {
             "label": "Hispanic population 25 years and over",
             "measures": [
@@ -49070,7 +49070,7 @@
             "MOE",
             "CV"
           ],
-          "is_survey": false,
+          "is_survey": true,
           "denominator": {
             "label": "Total households with a Hispanic householder",
             "measures": [
@@ -49159,7 +49159,7 @@
             "MOE",
             "CV"
           ],
-          "is_survey": false,
+          "is_survey": true,
           "denominator": {
             "label": "Total households with a Hispanic householder",
             "measures": [
@@ -49274,7 +49274,7 @@
             "NONE",
             "MOE"
           ],
-          "is_survey": false,
+          "is_survey": true,
           "denominator": {
             "label": "Hispanic 16 to 64 years",
             "measures": [
@@ -49392,7 +49392,7 @@
             "NONE",
             "MOE"
           ],
-          "is_survey": false,
+          "is_survey": true,
           "denominator": {
             "label": "Hispanic civilian employed population 16 to 64 years",
             "measures": [
@@ -49550,7 +49550,7 @@
             "MOE",
             "CV"
           ],
-          "is_survey": false,
+          "is_survey": true,
           "denominator": {
             "label": "Hispanic civilian employed population 16 to 64 years",
             "measures": [
@@ -49704,7 +49704,7 @@
             "NONE",
             "MOE"
           ],
-          "is_survey": false,
+          "is_survey": true,
           "denominator": {
             "label": "Hispanic civilian employed population 16 to 64 years",
             "measures": [
@@ -49982,7 +49982,7 @@
             "MOE",
             "CV"
           ],
-          "is_survey": false,
+          "is_survey": true,
           "denominator": {
             "label": "Hispanic civilian employed population 16 to 64 years",
             "measures": [
@@ -50211,7 +50211,7 @@
             "NONE",
             "MOE"
           ],
-          "is_survey": false,
+          "is_survey": true,
           "denominator": {
             "label": "White non-Hispanic population 25 years and over",
             "measures": [
@@ -50388,7 +50388,7 @@
             "MOE",
             "CV"
           ],
-          "is_survey": false,
+          "is_survey": true,
           "denominator": {
             "label": "Total households with a White non-Hispanic householder",
             "measures": [
@@ -50477,7 +50477,7 @@
             "MOE",
             "CV"
           ],
-          "is_survey": false,
+          "is_survey": true,
           "denominator": {
             "label": "Total households with a White non-Hispanic householder",
             "measures": [
@@ -50592,7 +50592,7 @@
             "NONE",
             "MOE"
           ],
-          "is_survey": false,
+          "is_survey": true,
           "denominator": {
             "label": "White non-Hispanic 16 to 64 years",
             "measures": [
@@ -50710,7 +50710,7 @@
             "NONE",
             "MOE"
           ],
-          "is_survey": false,
+          "is_survey": true,
           "denominator": {
             "label": "White non-Hispanic civilian employed population 16 to 64 years",
             "measures": [
@@ -50868,7 +50868,7 @@
             "MOE",
             "CV"
           ],
-          "is_survey": false,
+          "is_survey": true,
           "denominator": {
             "label": "White non-Hispanic civilian employed population 16 to 64 years",
             "measures": [
@@ -51022,7 +51022,7 @@
             "NONE",
             "MOE"
           ],
-          "is_survey": false,
+          "is_survey": true,
           "denominator": {
             "label": "White non-Hispanic civilian employed population 16 to 64 years",
             "measures": [
@@ -51300,7 +51300,7 @@
             "MOE",
             "CV"
           ],
-          "is_survey": false,
+          "is_survey": true,
           "denominator": {
             "label": "White non-Hispanic civilian employed population 16 to 64 years",
             "measures": [

--- a/generated/resolved_table_configs.json
+++ b/generated/resolved_table_configs.json
@@ -5719,6 +5719,7 @@
             "economics_1519_puma"
           ],
           "title": "Educational Attainment (Highest Grade Completed)",
+          "is_survey": true,
           "vintages": [
             "CENSUS PUMS, 2000",
             "ACS PUMS, 2008-2012",
@@ -5808,6 +5809,7 @@
             "economics_1519_puma"
           ],
           "title": "Median Household Income (2019 Dollars)",
+          "is_survey": true,
           "vintages": [
             "ACS PUMS, 2008-2012",
             "ACS PUMS, 2015-19"
@@ -5873,6 +5875,7 @@
             "economics_1519_puma"
           ],
           "title": "Households By Area Median Income (AMI) Band",
+          "is_survey": true,
           "vintages": [
             "ACS PUMS, 2015-19"
           ],
@@ -5952,6 +5955,7 @@
             "economics_1519_puma"
           ],
           "title": "Labor Force",
+          "is_survey": true,
           "vintages": [
             "ACS PUMS, 2008-2012",
             "ACS PUMS, 2015-19"
@@ -6038,6 +6042,7 @@
             "economics_1519_puma"
           ],
           "title": "Occupation",
+          "is_survey": true,
           "vintages": [
             "ACS PUMS, 2008-2012",
             "ACS PUMS, 2015-19"
@@ -6128,6 +6133,7 @@
             "economics_1519_puma"
           ],
           "title": "Median Wages By Occupation (2019 Dollars)",
+          "is_survey": true,
           "vintages": [
             "ACS PUMS, 2008-2012",
             "ACS PUMS, 2015-19"
@@ -6206,6 +6212,7 @@
             "economics_1519_puma"
           ],
           "title": "Industry",
+          "is_survey": true,
           "vintages": [
             "ACS PUMS, 2008-2012",
             "ACS PUMS, 2015-19"
@@ -6312,6 +6319,7 @@
             "economics_1519_puma"
           ],
           "title": "Median Wages By Industry (2019 Dollars)",
+          "is_survey": true,
           "vintages": [
             "ACS PUMS, 2008-2012",
             "ACS PUMS, 2015-19"
@@ -6408,6 +6416,7 @@
             "economics_1519_puma"
           ],
           "title": "Educational Attainment (Highest Grade Completed)",
+          "is_survey": true,
           "vintages": [
             "CENSUS PUMS, 2000",
             "ACS PUMS, 2008-2012",
@@ -6497,6 +6506,7 @@
             "economics_1519_puma"
           ],
           "title": "Median Household Income (2019 Dollars)",
+          "is_survey": true,
           "vintages": [
             "ACS PUMS, 2008-2012",
             "ACS PUMS, 2015-19"
@@ -6562,6 +6572,7 @@
             "economics_1519_puma"
           ],
           "title": "Households By Area Median Income (AMI) Band",
+          "is_survey": true,
           "vintages": [
             "ACS PUMS, 2015-19"
           ],
@@ -6641,6 +6652,7 @@
             "economics_1519_puma"
           ],
           "title": "Labor Force",
+          "is_survey": true,
           "vintages": [
             "ACS PUMS, 2008-2012",
             "ACS PUMS, 2015-19"
@@ -6727,6 +6739,7 @@
             "economics_1519_puma"
           ],
           "title": "Occupation",
+          "is_survey": true,
           "vintages": [
             "ACS PUMS, 2008-2012",
             "ACS PUMS, 2015-19"
@@ -6817,6 +6830,7 @@
             "economics_1519_puma"
           ],
           "title": "Median Wages By Occupation (2019 Dollars)",
+          "is_survey": true,
           "vintages": [
             "ACS PUMS, 2008-2012",
             "ACS PUMS, 2015-19"
@@ -6895,6 +6909,7 @@
             "economics_1519_puma"
           ],
           "title": "Industry",
+          "is_survey": true,
           "vintages": [
             "ACS PUMS, 2008-2012",
             "ACS PUMS, 2015-19"
@@ -7001,6 +7016,7 @@
             "economics_1519_puma"
           ],
           "title": "Median Wages By Industry (2019 Dollars)",
+          "is_survey": true,
           "vintages": [
             "ACS PUMS, 2008-2012",
             "ACS PUMS, 2015-19"
@@ -7097,6 +7113,7 @@
             "economics_1519_puma"
           ],
           "title": "Educational Attainment (Highest Grade Completed)",
+          "is_survey": true,
           "vintages": [
             "CENSUS PUMS, 2000",
             "ACS PUMS, 2008-2012",
@@ -7186,6 +7203,7 @@
             "economics_1519_puma"
           ],
           "title": "Median Household Income (2019 Dollars)",
+          "is_survey": true,
           "vintages": [
             "ACS PUMS, 2008-2012",
             "ACS PUMS, 2015-19"
@@ -7251,6 +7269,7 @@
             "economics_1519_puma"
           ],
           "title": "Households By Area Median Income (AMI) Band",
+          "is_survey": true,
           "vintages": [
             "ACS PUMS, 2015-19"
           ],
@@ -7330,6 +7349,7 @@
             "economics_1519_puma"
           ],
           "title": "Labor Force",
+          "is_survey": true,
           "vintages": [
             "ACS PUMS, 2008-2012",
             "ACS PUMS, 2015-19"
@@ -7416,6 +7436,7 @@
             "economics_1519_puma"
           ],
           "title": "Occupation",
+          "is_survey": true,
           "vintages": [
             "ACS PUMS, 2008-2012",
             "ACS PUMS, 2015-19"
@@ -7506,6 +7527,7 @@
             "economics_1519_puma"
           ],
           "title": "Median Wages By Occupation (2019 Dollars)",
+          "is_survey": true,
           "vintages": [
             "ACS PUMS, 2008-2012",
             "ACS PUMS, 2015-19"
@@ -7584,6 +7606,7 @@
             "economics_1519_puma"
           ],
           "title": "Industry",
+          "is_survey": true,
           "vintages": [
             "ACS PUMS, 2008-2012",
             "ACS PUMS, 2015-19"
@@ -7690,6 +7713,7 @@
             "economics_1519_puma"
           ],
           "title": "Median Wages By Industry (2019 Dollars)",
+          "is_survey": true,
           "vintages": [
             "ACS PUMS, 2008-2012",
             "ACS PUMS, 2015-19"
@@ -7786,6 +7810,7 @@
             "economics_1519_puma"
           ],
           "title": "Educational Attainment (Highest Grade Completed)",
+          "is_survey": true,
           "vintages": [
             "CENSUS PUMS, 2000",
             "ACS PUMS, 2008-2012",
@@ -7875,6 +7900,7 @@
             "economics_1519_puma"
           ],
           "title": "Median Household Income (2019 Dollars)",
+          "is_survey": true,
           "vintages": [
             "ACS PUMS, 2008-2012",
             "ACS PUMS, 2015-19"
@@ -7940,6 +7966,7 @@
             "economics_1519_puma"
           ],
           "title": "Households By Area Median Income (AMI) Band",
+          "is_survey": true,
           "vintages": [
             "ACS PUMS, 2015-19"
           ],
@@ -8019,6 +8046,7 @@
             "economics_1519_puma"
           ],
           "title": "Labor Force",
+          "is_survey": true,
           "vintages": [
             "ACS PUMS, 2008-2012",
             "ACS PUMS, 2015-19"
@@ -8105,6 +8133,7 @@
             "economics_1519_puma"
           ],
           "title": "Occupation",
+          "is_survey": true,
           "vintages": [
             "ACS PUMS, 2008-2012",
             "ACS PUMS, 2015-19"
@@ -8195,6 +8224,7 @@
             "economics_1519_puma"
           ],
           "title": "Median Wages By Occupation (2019 Dollars)",
+          "is_survey": true,
           "vintages": [
             "ACS PUMS, 2008-2012",
             "ACS PUMS, 2015-19"
@@ -8273,6 +8303,7 @@
             "economics_1519_puma"
           ],
           "title": "Industry",
+          "is_survey": true,
           "vintages": [
             "ACS PUMS, 2008-2012",
             "ACS PUMS, 2015-19"
@@ -8379,6 +8410,7 @@
             "economics_1519_puma"
           ],
           "title": "Median Wages By Industry (2019 Dollars)",
+          "is_survey": true,
           "vintages": [
             "ACS PUMS, 2008-2012",
             "ACS PUMS, 2015-19"
@@ -8475,6 +8507,7 @@
             "economics_1519_puma"
           ],
           "title": "Educational Attainment (Highest Grade Completed)",
+          "is_survey": true,
           "vintages": [
             "CENSUS PUMS, 2000",
             "ACS PUMS, 2008-2012",
@@ -8564,6 +8597,7 @@
             "economics_1519_puma"
           ],
           "title": "Median Household Income (2019 Dollars)",
+          "is_survey": true,
           "vintages": [
             "ACS PUMS, 2008-2012",
             "ACS PUMS, 2015-19"
@@ -8629,6 +8663,7 @@
             "economics_1519_puma"
           ],
           "title": "Households By Area Median Income (AMI) Band",
+          "is_survey": true,
           "vintages": [
             "ACS PUMS, 2015-19"
           ],
@@ -8708,6 +8743,7 @@
             "economics_1519_puma"
           ],
           "title": "Labor Force",
+          "is_survey": true,
           "vintages": [
             "ACS PUMS, 2008-2012",
             "ACS PUMS, 2015-19"
@@ -8794,6 +8830,7 @@
             "economics_1519_puma"
           ],
           "title": "Occupation",
+          "is_survey": true,
           "vintages": [
             "ACS PUMS, 2008-2012",
             "ACS PUMS, 2015-19"
@@ -8884,6 +8921,7 @@
             "economics_1519_puma"
           ],
           "title": "Median Wages By Occupation (2019 Dollars)",
+          "is_survey": true,
           "vintages": [
             "ACS PUMS, 2008-2012",
             "ACS PUMS, 2015-19"
@@ -8962,6 +9000,7 @@
             "economics_1519_puma"
           ],
           "title": "Industry",
+          "is_survey": true,
           "vintages": [
             "ACS PUMS, 2008-2012",
             "ACS PUMS, 2015-19"
@@ -9068,6 +9107,7 @@
             "economics_1519_puma"
           ],
           "title": "Median Wages By Industry (2019 Dollars)",
+          "is_survey": true,
           "vintages": [
             "ACS PUMS, 2008-2012",
             "ACS PUMS, 2015-19"
@@ -19032,6 +19072,7 @@
             "economics_1519_borough"
           ],
           "title": "Educational Attainment (Highest Grade Completed)",
+          "is_survey": true,
           "vintages": [
             "CENSUS PUMS, 2000",
             "ACS PUMS, 2008-2012",
@@ -19121,6 +19162,7 @@
             "economics_1519_borough"
           ],
           "title": "Median Household Income (2019 Dollars)",
+          "is_survey": true,
           "vintages": [
             "ACS PUMS, 2008-2012",
             "ACS PUMS, 2015-19"
@@ -19186,6 +19228,7 @@
             "economics_1519_borough"
           ],
           "title": "Households By Area Median Income (AMI) Band",
+          "is_survey": true,
           "vintages": [
             "ACS PUMS, 2015-19"
           ],
@@ -19265,6 +19308,7 @@
             "economics_1519_borough"
           ],
           "title": "Labor Force",
+          "is_survey": true,
           "vintages": [
             "ACS PUMS, 2008-2012",
             "ACS PUMS, 2015-19"
@@ -19351,6 +19395,7 @@
             "economics_1519_borough"
           ],
           "title": "Occupation",
+          "is_survey": true,
           "vintages": [
             "ACS PUMS, 2008-2012",
             "ACS PUMS, 2015-19"
@@ -19441,6 +19486,7 @@
             "economics_1519_borough"
           ],
           "title": "Median Wages By Occupation (2019 Dollars)",
+          "is_survey": true,
           "vintages": [
             "ACS PUMS, 2008-2012",
             "ACS PUMS, 2015-19"
@@ -19519,6 +19565,7 @@
             "economics_1519_borough"
           ],
           "title": "Industry",
+          "is_survey": true,
           "vintages": [
             "ACS PUMS, 2008-2012",
             "ACS PUMS, 2015-19"
@@ -19625,6 +19672,7 @@
             "economics_1519_borough"
           ],
           "title": "Median Wages By Industry (2019 Dollars)",
+          "is_survey": true,
           "vintages": [
             "ACS PUMS, 2008-2012",
             "ACS PUMS, 2015-19"
@@ -19721,6 +19769,7 @@
             "economics_1519_borough"
           ],
           "title": "Educational Attainment (Highest Grade Completed)",
+          "is_survey": true,
           "vintages": [
             "CENSUS PUMS, 2000",
             "ACS PUMS, 2008-2012",
@@ -19810,6 +19859,7 @@
             "economics_1519_borough"
           ],
           "title": "Median Household Income (2019 Dollars)",
+          "is_survey": true,
           "vintages": [
             "ACS PUMS, 2008-2012",
             "ACS PUMS, 2015-19"
@@ -19875,6 +19925,7 @@
             "economics_1519_borough"
           ],
           "title": "Households By Area Median Income (AMI) Band",
+          "is_survey": true,
           "vintages": [
             "ACS PUMS, 2015-19"
           ],
@@ -19954,6 +20005,7 @@
             "economics_1519_borough"
           ],
           "title": "Labor Force",
+          "is_survey": true,
           "vintages": [
             "ACS PUMS, 2008-2012",
             "ACS PUMS, 2015-19"
@@ -20040,6 +20092,7 @@
             "economics_1519_borough"
           ],
           "title": "Occupation",
+          "is_survey": true,
           "vintages": [
             "ACS PUMS, 2008-2012",
             "ACS PUMS, 2015-19"
@@ -20130,6 +20183,7 @@
             "economics_1519_borough"
           ],
           "title": "Median Wages By Occupation (2019 Dollars)",
+          "is_survey": true,
           "vintages": [
             "ACS PUMS, 2008-2012",
             "ACS PUMS, 2015-19"
@@ -20208,6 +20262,7 @@
             "economics_1519_borough"
           ],
           "title": "Industry",
+          "is_survey": true,
           "vintages": [
             "ACS PUMS, 2008-2012",
             "ACS PUMS, 2015-19"
@@ -20314,6 +20369,7 @@
             "economics_1519_borough"
           ],
           "title": "Median Wages By Industry (2019 Dollars)",
+          "is_survey": true,
           "vintages": [
             "ACS PUMS, 2008-2012",
             "ACS PUMS, 2015-19"
@@ -20410,6 +20466,7 @@
             "economics_1519_borough"
           ],
           "title": "Educational Attainment (Highest Grade Completed)",
+          "is_survey": true,
           "vintages": [
             "CENSUS PUMS, 2000",
             "ACS PUMS, 2008-2012",
@@ -20499,6 +20556,7 @@
             "economics_1519_borough"
           ],
           "title": "Median Household Income (2019 Dollars)",
+          "is_survey": true,
           "vintages": [
             "ACS PUMS, 2008-2012",
             "ACS PUMS, 2015-19"
@@ -20564,6 +20622,7 @@
             "economics_1519_borough"
           ],
           "title": "Households By Area Median Income (AMI) Band",
+          "is_survey": true,
           "vintages": [
             "ACS PUMS, 2015-19"
           ],
@@ -20643,6 +20702,7 @@
             "economics_1519_borough"
           ],
           "title": "Labor Force",
+          "is_survey": true,
           "vintages": [
             "ACS PUMS, 2008-2012",
             "ACS PUMS, 2015-19"
@@ -20729,6 +20789,7 @@
             "economics_1519_borough"
           ],
           "title": "Occupation",
+          "is_survey": true,
           "vintages": [
             "ACS PUMS, 2008-2012",
             "ACS PUMS, 2015-19"
@@ -20819,6 +20880,7 @@
             "economics_1519_borough"
           ],
           "title": "Median Wages By Occupation (2019 Dollars)",
+          "is_survey": true,
           "vintages": [
             "ACS PUMS, 2008-2012",
             "ACS PUMS, 2015-19"
@@ -20897,6 +20959,7 @@
             "economics_1519_borough"
           ],
           "title": "Industry",
+          "is_survey": true,
           "vintages": [
             "ACS PUMS, 2008-2012",
             "ACS PUMS, 2015-19"
@@ -21003,6 +21066,7 @@
             "economics_1519_borough"
           ],
           "title": "Median Wages By Industry (2019 Dollars)",
+          "is_survey": true,
           "vintages": [
             "ACS PUMS, 2008-2012",
             "ACS PUMS, 2015-19"
@@ -21099,6 +21163,7 @@
             "economics_1519_borough"
           ],
           "title": "Educational Attainment (Highest Grade Completed)",
+          "is_survey": true,
           "vintages": [
             "CENSUS PUMS, 2000",
             "ACS PUMS, 2008-2012",
@@ -21188,6 +21253,7 @@
             "economics_1519_borough"
           ],
           "title": "Median Household Income (2019 Dollars)",
+          "is_survey": true,
           "vintages": [
             "ACS PUMS, 2008-2012",
             "ACS PUMS, 2015-19"
@@ -21253,6 +21319,7 @@
             "economics_1519_borough"
           ],
           "title": "Households By Area Median Income (AMI) Band",
+          "is_survey": true,
           "vintages": [
             "ACS PUMS, 2015-19"
           ],
@@ -21332,6 +21399,7 @@
             "economics_1519_borough"
           ],
           "title": "Labor Force",
+          "is_survey": true,
           "vintages": [
             "ACS PUMS, 2008-2012",
             "ACS PUMS, 2015-19"
@@ -21418,6 +21486,7 @@
             "economics_1519_borough"
           ],
           "title": "Occupation",
+          "is_survey": true,
           "vintages": [
             "ACS PUMS, 2008-2012",
             "ACS PUMS, 2015-19"
@@ -21508,6 +21577,7 @@
             "economics_1519_borough"
           ],
           "title": "Median Wages By Occupation (2019 Dollars)",
+          "is_survey": true,
           "vintages": [
             "ACS PUMS, 2008-2012",
             "ACS PUMS, 2015-19"
@@ -21586,6 +21656,7 @@
             "economics_1519_borough"
           ],
           "title": "Industry",
+          "is_survey": true,
           "vintages": [
             "ACS PUMS, 2008-2012",
             "ACS PUMS, 2015-19"
@@ -21692,6 +21763,7 @@
             "economics_1519_borough"
           ],
           "title": "Median Wages By Industry (2019 Dollars)",
+          "is_survey": true,
           "vintages": [
             "ACS PUMS, 2008-2012",
             "ACS PUMS, 2015-19"
@@ -21788,6 +21860,7 @@
             "economics_1519_borough"
           ],
           "title": "Educational Attainment (Highest Grade Completed)",
+          "is_survey": true,
           "vintages": [
             "CENSUS PUMS, 2000",
             "ACS PUMS, 2008-2012",
@@ -21877,6 +21950,7 @@
             "economics_1519_borough"
           ],
           "title": "Median Household Income (2019 Dollars)",
+          "is_survey": true,
           "vintages": [
             "ACS PUMS, 2008-2012",
             "ACS PUMS, 2015-19"
@@ -21942,6 +22016,7 @@
             "economics_1519_borough"
           ],
           "title": "Households By Area Median Income (AMI) Band",
+          "is_survey": true,
           "vintages": [
             "ACS PUMS, 2015-19"
           ],
@@ -22021,6 +22096,7 @@
             "economics_1519_borough"
           ],
           "title": "Labor Force",
+          "is_survey": true,
           "vintages": [
             "ACS PUMS, 2008-2012",
             "ACS PUMS, 2015-19"
@@ -22107,6 +22183,7 @@
             "economics_1519_borough"
           ],
           "title": "Occupation",
+          "is_survey": true,
           "vintages": [
             "ACS PUMS, 2008-2012",
             "ACS PUMS, 2015-19"
@@ -22197,6 +22274,7 @@
             "economics_1519_borough"
           ],
           "title": "Median Wages By Occupation (2019 Dollars)",
+          "is_survey": true,
           "vintages": [
             "ACS PUMS, 2008-2012",
             "ACS PUMS, 2015-19"
@@ -22275,6 +22353,7 @@
             "economics_1519_borough"
           ],
           "title": "Industry",
+          "is_survey": true,
           "vintages": [
             "ACS PUMS, 2008-2012",
             "ACS PUMS, 2015-19"
@@ -22381,6 +22460,7 @@
             "economics_1519_borough"
           ],
           "title": "Median Wages By Industry (2019 Dollars)",
+          "is_survey": true,
           "vintages": [
             "ACS PUMS, 2008-2012",
             "ACS PUMS, 2015-19"
@@ -32356,6 +32436,7 @@
             "economics_1519_citywide"
           ],
           "title": "Educational Attainment (Highest Grade Completed)",
+          "is_survey": true,
           "vintages": [
             "CENSUS PUMS, 2000",
             "ACS PUMS, 2008-2012",
@@ -32445,6 +32526,7 @@
             "economics_1519_citywide"
           ],
           "title": "Median Household Income (2019 Dollars)",
+          "is_survey": true,
           "vintages": [
             "ACS PUMS, 2008-2012",
             "ACS PUMS, 2015-19"
@@ -32510,6 +32592,7 @@
             "economics_1519_citywide"
           ],
           "title": "Households By Area Median Income (AMI) Band",
+          "is_survey": true,
           "vintages": [
             "ACS PUMS, 2015-19"
           ],
@@ -32589,6 +32672,7 @@
             "economics_1519_citywide"
           ],
           "title": "Labor Force",
+          "is_survey": true,
           "vintages": [
             "ACS PUMS, 2008-2012",
             "ACS PUMS, 2015-19"
@@ -32675,6 +32759,7 @@
             "economics_1519_citywide"
           ],
           "title": "Occupation",
+          "is_survey": true,
           "vintages": [
             "ACS PUMS, 2008-2012",
             "ACS PUMS, 2015-19"
@@ -32765,6 +32850,7 @@
             "economics_1519_citywide"
           ],
           "title": "Median Wages By Occupation (2019 Dollars)",
+          "is_survey": true,
           "vintages": [
             "ACS PUMS, 2008-2012",
             "ACS PUMS, 2015-19"
@@ -32843,6 +32929,7 @@
             "economics_1519_citywide"
           ],
           "title": "Industry",
+          "is_survey": true,
           "vintages": [
             "ACS PUMS, 2008-2012",
             "ACS PUMS, 2015-19"
@@ -32949,6 +33036,7 @@
             "economics_1519_citywide"
           ],
           "title": "Median Wages By Industry (2019 Dollars)",
+          "is_survey": true,
           "vintages": [
             "ACS PUMS, 2008-2012",
             "ACS PUMS, 2015-19"
@@ -33045,6 +33133,7 @@
             "economics_1519_citywide"
           ],
           "title": "Educational Attainment (Highest Grade Completed)",
+          "is_survey": true,
           "vintages": [
             "CENSUS PUMS, 2000",
             "ACS PUMS, 2008-2012",
@@ -33134,6 +33223,7 @@
             "economics_1519_citywide"
           ],
           "title": "Median Household Income (2019 Dollars)",
+          "is_survey": true,
           "vintages": [
             "ACS PUMS, 2008-2012",
             "ACS PUMS, 2015-19"
@@ -33199,6 +33289,7 @@
             "economics_1519_citywide"
           ],
           "title": "Households By Area Median Income (AMI) Band",
+          "is_survey": true,
           "vintages": [
             "ACS PUMS, 2015-19"
           ],
@@ -33278,6 +33369,7 @@
             "economics_1519_citywide"
           ],
           "title": "Labor Force",
+          "is_survey": true,
           "vintages": [
             "ACS PUMS, 2008-2012",
             "ACS PUMS, 2015-19"
@@ -33364,6 +33456,7 @@
             "economics_1519_citywide"
           ],
           "title": "Occupation",
+          "is_survey": true,
           "vintages": [
             "ACS PUMS, 2008-2012",
             "ACS PUMS, 2015-19"
@@ -33454,6 +33547,7 @@
             "economics_1519_citywide"
           ],
           "title": "Median Wages By Occupation (2019 Dollars)",
+          "is_survey": true,
           "vintages": [
             "ACS PUMS, 2008-2012",
             "ACS PUMS, 2015-19"
@@ -33532,6 +33626,7 @@
             "economics_1519_citywide"
           ],
           "title": "Industry",
+          "is_survey": true,
           "vintages": [
             "ACS PUMS, 2008-2012",
             "ACS PUMS, 2015-19"
@@ -33638,6 +33733,7 @@
             "economics_1519_citywide"
           ],
           "title": "Median Wages By Industry (2019 Dollars)",
+          "is_survey": true,
           "vintages": [
             "ACS PUMS, 2008-2012",
             "ACS PUMS, 2015-19"
@@ -33734,6 +33830,7 @@
             "economics_1519_citywide"
           ],
           "title": "Educational Attainment (Highest Grade Completed)",
+          "is_survey": true,
           "vintages": [
             "CENSUS PUMS, 2000",
             "ACS PUMS, 2008-2012",
@@ -33823,6 +33920,7 @@
             "economics_1519_citywide"
           ],
           "title": "Median Household Income (2019 Dollars)",
+          "is_survey": true,
           "vintages": [
             "ACS PUMS, 2008-2012",
             "ACS PUMS, 2015-19"
@@ -33888,6 +33986,7 @@
             "economics_1519_citywide"
           ],
           "title": "Households By Area Median Income (AMI) Band",
+          "is_survey": true,
           "vintages": [
             "ACS PUMS, 2015-19"
           ],
@@ -33967,6 +34066,7 @@
             "economics_1519_citywide"
           ],
           "title": "Labor Force",
+          "is_survey": true,
           "vintages": [
             "ACS PUMS, 2008-2012",
             "ACS PUMS, 2015-19"
@@ -34053,6 +34153,7 @@
             "economics_1519_citywide"
           ],
           "title": "Occupation",
+          "is_survey": true,
           "vintages": [
             "ACS PUMS, 2008-2012",
             "ACS PUMS, 2015-19"
@@ -34143,6 +34244,7 @@
             "economics_1519_citywide"
           ],
           "title": "Median Wages By Occupation (2019 Dollars)",
+          "is_survey": true,
           "vintages": [
             "ACS PUMS, 2008-2012",
             "ACS PUMS, 2015-19"
@@ -34221,6 +34323,7 @@
             "economics_1519_citywide"
           ],
           "title": "Industry",
+          "is_survey": true,
           "vintages": [
             "ACS PUMS, 2008-2012",
             "ACS PUMS, 2015-19"
@@ -34327,6 +34430,7 @@
             "economics_1519_citywide"
           ],
           "title": "Median Wages By Industry (2019 Dollars)",
+          "is_survey": true,
           "vintages": [
             "ACS PUMS, 2008-2012",
             "ACS PUMS, 2015-19"
@@ -34423,6 +34527,7 @@
             "economics_1519_citywide"
           ],
           "title": "Educational Attainment (Highest Grade Completed)",
+          "is_survey": true,
           "vintages": [
             "CENSUS PUMS, 2000",
             "ACS PUMS, 2008-2012",
@@ -34512,6 +34617,7 @@
             "economics_1519_citywide"
           ],
           "title": "Median Household Income (2019 Dollars)",
+          "is_survey": true,
           "vintages": [
             "ACS PUMS, 2008-2012",
             "ACS PUMS, 2015-19"
@@ -34577,6 +34683,7 @@
             "economics_1519_citywide"
           ],
           "title": "Households By Area Median Income (AMI) Band",
+          "is_survey": true,
           "vintages": [
             "ACS PUMS, 2015-19"
           ],
@@ -34656,6 +34763,7 @@
             "economics_1519_citywide"
           ],
           "title": "Labor Force",
+          "is_survey": true,
           "vintages": [
             "ACS PUMS, 2008-2012",
             "ACS PUMS, 2015-19"
@@ -34742,6 +34850,7 @@
             "economics_1519_citywide"
           ],
           "title": "Occupation",
+          "is_survey": true,
           "vintages": [
             "ACS PUMS, 2008-2012",
             "ACS PUMS, 2015-19"
@@ -34832,6 +34941,7 @@
             "economics_1519_citywide"
           ],
           "title": "Median Wages By Occupation (2019 Dollars)",
+          "is_survey": true,
           "vintages": [
             "ACS PUMS, 2008-2012",
             "ACS PUMS, 2015-19"
@@ -34910,6 +35020,7 @@
             "economics_1519_citywide"
           ],
           "title": "Industry",
+          "is_survey": true,
           "vintages": [
             "ACS PUMS, 2008-2012",
             "ACS PUMS, 2015-19"
@@ -35016,6 +35127,7 @@
             "economics_1519_citywide"
           ],
           "title": "Median Wages By Industry (2019 Dollars)",
+          "is_survey": true,
           "vintages": [
             "ACS PUMS, 2008-2012",
             "ACS PUMS, 2015-19"
@@ -35112,6 +35224,7 @@
             "economics_1519_citywide"
           ],
           "title": "Educational Attainment (Highest Grade Completed)",
+          "is_survey": true,
           "vintages": [
             "CENSUS PUMS, 2000",
             "ACS PUMS, 2008-2012",
@@ -35201,6 +35314,7 @@
             "economics_1519_citywide"
           ],
           "title": "Median Household Income (2019 Dollars)",
+          "is_survey": true,
           "vintages": [
             "ACS PUMS, 2008-2012",
             "ACS PUMS, 2015-19"
@@ -35266,6 +35380,7 @@
             "economics_1519_citywide"
           ],
           "title": "Households By Area Median Income (AMI) Band",
+          "is_survey": true,
           "vintages": [
             "ACS PUMS, 2015-19"
           ],
@@ -35345,6 +35460,7 @@
             "economics_1519_citywide"
           ],
           "title": "Labor Force",
+          "is_survey": true,
           "vintages": [
             "ACS PUMS, 2008-2012",
             "ACS PUMS, 2015-19"
@@ -35431,6 +35547,7 @@
             "economics_1519_citywide"
           ],
           "title": "Occupation",
+          "is_survey": true,
           "vintages": [
             "ACS PUMS, 2008-2012",
             "ACS PUMS, 2015-19"
@@ -35521,6 +35638,7 @@
             "economics_1519_citywide"
           ],
           "title": "Median Wages By Occupation (2019 Dollars)",
+          "is_survey": true,
           "vintages": [
             "ACS PUMS, 2008-2012",
             "ACS PUMS, 2015-19"
@@ -35599,6 +35717,7 @@
             "economics_1519_citywide"
           ],
           "title": "Industry",
+          "is_survey": true,
           "vintages": [
             "ACS PUMS, 2008-2012",
             "ACS PUMS, 2015-19"
@@ -35705,6 +35824,7 @@
             "economics_1519_citywide"
           ],
           "title": "Median Wages By Industry (2019 Dollars)",
+          "is_survey": true,
           "vintages": [
             "ACS PUMS, 2008-2012",
             "ACS PUMS, 2015-19"


### PR DESCRIPTION
The econ tables were missing the `is_survey` flag, causing this to happen when a user hides reliability:
<img width="1130" alt="image" src="https://user-images.githubusercontent.com/9055367/161849562-f86e2068-8cd0-4831-9f6f-35ceb026a305.png">

This PR fixes that.