### PR TITLE
7952 Fix incorrect denominator label in nycha tenants table

### DIFF
--- a/config/hsaq.json
+++ b/config/hsaq.json
@@ -614,7 +614,6 @@
       "title": "Population In NYC Housing Authority Housing",
       "vintages": ["NYC HOUSING AUTHORITY, 2022"],
       "denominator": {
-        "label": "Occupied housing units",
         "variable": "pop",
         "measures": ["COUNT","PERCENT"],
         "variances": ["NONE","NONE"]

--- a/generated/resolved_pages.json
+++ b/generated/resolved_pages.json
@@ -1057,7 +1057,7 @@
           ],
           "is_survey": false,
           "denominator": {
-            "label": "Occupied housing units",
+            "label": "Total population",
             "measures": [
               "COUNT",
               "PERCENT"
@@ -2022,7 +2022,7 @@
           ],
           "is_survey": false,
           "denominator": {
-            "label": "Occupied housing units",
+            "label": "Asian non-Hispanic population",
             "measures": [
               "COUNT",
               "PERCENT"
@@ -2987,7 +2987,7 @@
           ],
           "is_survey": false,
           "denominator": {
-            "label": "Occupied housing units",
+            "label": "Black non-Hispanic population",
             "measures": [
               "COUNT",
               "PERCENT"
@@ -3952,7 +3952,7 @@
           ],
           "is_survey": false,
           "denominator": {
-            "label": "Occupied housing units",
+            "label": "White non-Hispanic population",
             "measures": [
               "COUNT",
               "PERCENT"
@@ -4917,7 +4917,7 @@
           ],
           "is_survey": false,
           "denominator": {
-            "label": "Occupied housing units",
+            "label": "Hispanic population",
             "measures": [
               "COUNT",
               "PERCENT"
@@ -19995,7 +19995,7 @@
           ],
           "is_survey": false,
           "denominator": {
-            "label": "Occupied housing units",
+            "label": "Total population",
             "measures": [
               "COUNT",
               "PERCENT"
@@ -20960,7 +20960,7 @@
           ],
           "is_survey": false,
           "denominator": {
-            "label": "Occupied housing units",
+            "label": "Asian non-Hispanic population",
             "measures": [
               "COUNT",
               "PERCENT"
@@ -21925,7 +21925,7 @@
           ],
           "is_survey": false,
           "denominator": {
-            "label": "Occupied housing units",
+            "label": "Black non-Hispanic population",
             "measures": [
               "COUNT",
               "PERCENT"
@@ -22890,7 +22890,7 @@
           ],
           "is_survey": false,
           "denominator": {
-            "label": "Occupied housing units",
+            "label": "White non-Hispanic population",
             "measures": [
               "COUNT",
               "PERCENT"
@@ -23855,7 +23855,7 @@
           ],
           "is_survey": false,
           "denominator": {
-            "label": "Occupied housing units",
+            "label": "Hispanic population",
             "measures": [
               "COUNT",
               "PERCENT"
@@ -38927,7 +38927,7 @@
           ],
           "is_survey": false,
           "denominator": {
-            "label": "Occupied housing units",
+            "label": "Total population",
             "measures": [
               "COUNT",
               "PERCENT"
@@ -39892,7 +39892,7 @@
           ],
           "is_survey": false,
           "denominator": {
-            "label": "Occupied housing units",
+            "label": "Asian non-Hispanic population",
             "measures": [
               "COUNT",
               "PERCENT"
@@ -40857,7 +40857,7 @@
           ],
           "is_survey": false,
           "denominator": {
-            "label": "Occupied housing units",
+            "label": "Black non-Hispanic population",
             "measures": [
               "COUNT",
               "PERCENT"
@@ -41822,7 +41822,7 @@
           ],
           "is_survey": false,
           "denominator": {
-            "label": "Occupied housing units",
+            "label": "White non-Hispanic population",
             "measures": [
               "COUNT",
               "PERCENT"
@@ -42787,7 +42787,7 @@
           ],
           "is_survey": false,
           "denominator": {
-            "label": "Occupied housing units",
+            "label": "Hispanic population",
             "measures": [
               "COUNT",
               "PERCENT"

--- a/generated/resolved_table_configs.json
+++ b/generated/resolved_table_configs.json
@@ -786,7 +786,7 @@
         },
         {
           "denominator": {
-            "label": "Occupied housing units",
+            "label": "Total population",
             "variable": "pop",
             "measures": [
               "COUNT",
@@ -1623,7 +1623,7 @@
         },
         {
           "denominator": {
-            "label": "Occupied housing units",
+            "label": "Asian non-Hispanic population",
             "variable": "pop",
             "measures": [
               "COUNT",
@@ -2460,7 +2460,7 @@
         },
         {
           "denominator": {
-            "label": "Occupied housing units",
+            "label": "Black non-Hispanic population",
             "variable": "pop",
             "measures": [
               "COUNT",
@@ -3297,7 +3297,7 @@
         },
         {
           "denominator": {
-            "label": "Occupied housing units",
+            "label": "White non-Hispanic population",
             "variable": "pop",
             "measures": [
               "COUNT",
@@ -4134,7 +4134,7 @@
         },
         {
           "denominator": {
-            "label": "Occupied housing units",
+            "label": "Hispanic population",
             "variable": "pop",
             "measures": [
               "COUNT",
@@ -14374,7 +14374,7 @@
         },
         {
           "denominator": {
-            "label": "Occupied housing units",
+            "label": "Total population",
             "variable": "pop",
             "measures": [
               "COUNT",
@@ -15211,7 +15211,7 @@
         },
         {
           "denominator": {
-            "label": "Occupied housing units",
+            "label": "Asian non-Hispanic population",
             "variable": "pop",
             "measures": [
               "COUNT",
@@ -16048,7 +16048,7 @@
         },
         {
           "denominator": {
-            "label": "Occupied housing units",
+            "label": "Black non-Hispanic population",
             "variable": "pop",
             "measures": [
               "COUNT",
@@ -16885,7 +16885,7 @@
         },
         {
           "denominator": {
-            "label": "Occupied housing units",
+            "label": "White non-Hispanic population",
             "variable": "pop",
             "measures": [
               "COUNT",
@@ -17722,7 +17722,7 @@
         },
         {
           "denominator": {
-            "label": "Occupied housing units",
+            "label": "Hispanic population",
             "variable": "pop",
             "measures": [
               "COUNT",
@@ -27963,7 +27963,7 @@
         },
         {
           "denominator": {
-            "label": "Occupied housing units",
+            "label": "Total population",
             "variable": "pop",
             "measures": [
               "COUNT",
@@ -28800,7 +28800,7 @@
         },
         {
           "denominator": {
-            "label": "Occupied housing units",
+            "label": "Asian non-Hispanic population",
             "variable": "pop",
             "measures": [
               "COUNT",
@@ -29637,7 +29637,7 @@
         },
         {
           "denominator": {
-            "label": "Occupied housing units",
+            "label": "Black non-Hispanic population",
             "variable": "pop",
             "measures": [
               "COUNT",
@@ -30474,7 +30474,7 @@
         },
         {
           "denominator": {
-            "label": "Occupied housing units",
+            "label": "White non-Hispanic population",
             "variable": "pop",
             "measures": [
               "COUNT",
@@ -31311,7 +31311,7 @@
         },
         {
           "denominator": {
-            "label": "Occupied housing units",
+            "label": "Hispanic population",
             "variable": "pop",
             "measures": [
               "COUNT",


### PR DESCRIPTION
This PR just fixes some incorrect copy in the denominators for "Population in NYC Housing Authority Housing"